### PR TITLE
Add support for delayUntil

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -66,10 +66,10 @@
       },
       {
         "package": "jobs",
-        "repositoryURL": "https://github.com/vapor/jobs.git",
+        "repositoryURL": "https://github.com/tonyarnold/jobs.git",
         "state": {
-          "branch": "3",
-          "revision": "9a62a1b940bd64a1b077ff8daf67d4bd8a6bed27",
+          "branch": "feature/backport-delay-until-to-3",
+          "revision": "2697f76b9fb4becf9c53e3da70f099197d84652e",
           "version": null
         }
       },

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/vapor/console.git",
         "state": {
           "branch": null,
-          "revision": "d6cf07af59ae63cd95c4b5f98cf1f25627750fd1",
-          "version": "3.1.0"
+          "revision": "74cfbea629d4aac34a97cead2447a6870af1950b",
+          "version": "3.1.1"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/vapor/core.git",
         "state": {
           "branch": null,
-          "revision": "439d6dcd6c520451ae30d39b2ca9f2aba96c22f4",
-          "version": "3.7.0"
+          "revision": "18f2436bf7a6bc2224372c0885db2e0159af1649",
+          "version": "3.9.2"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/vapor/crypto.git",
         "state": {
           "branch": null,
-          "revision": "45bb12d13cdec80dbd1cc0685ea002e51ab83439",
-          "version": "3.3.2"
+          "revision": "df8eb7d8ae51787b3a0628aa3975e67666da936c",
+          "version": "3.3.3"
         }
       },
       {
@@ -42,13 +42,13 @@
         "repositoryURL": "https://github.com/vapor/fluent.git",
         "state": {
           "branch": null,
-          "revision": "3776a0f623e08b413e878f282a70e8952651c91f",
-          "version": "3.1.3"
+          "revision": "783819d8838d15e1a05b459aa0fd1bde1e37ac26",
+          "version": "3.2.1"
         }
       },
       {
         "package": "FluentPostgreSQL",
-        "repositoryURL": "https://github.com/vapor/fluent-postgresql.git",
+        "repositoryURL": "https://github.com/vapor/fluent-postgres-driver.git",
         "state": {
           "branch": null,
           "revision": "8e3eb9d24d54ac58c8d04c194ad6b24f0b1b667e",
@@ -60,17 +60,17 @@
         "repositoryURL": "https://github.com/vapor/http.git",
         "state": {
           "branch": null,
-          "revision": "b57005e0de30ba36372ac41bfce1ac12b2bc3272",
-          "version": "3.1.8"
+          "revision": "3808ed0401379b6e9f4a053f03090ea9d658caa9",
+          "version": "3.2.1"
         }
       },
       {
         "package": "jobs",
-        "repositoryURL": "https://github.com/vapor-community/jobs.git",
+        "repositoryURL": "https://github.com/vapor/jobs.git",
         "state": {
-          "branch": null,
-          "revision": "fbe1778181387e7d9fd05263b2e5b4f936e5c23c",
-          "version": "0.2.4"
+          "branch": "3",
+          "revision": "9a62a1b940bd64a1b077ff8daf67d4bd8a6bed27",
+          "version": null
         }
       },
       {
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/vapor/multipart.git",
         "state": {
           "branch": null,
-          "revision": "bd7736c5f28e48ed8b683dcc9df3dcd346064c2b",
-          "version": "3.0.3"
+          "revision": "f063180d0b84832accd33194e06ed3c41f8609ac",
+          "version": "3.1.1"
         }
       },
       {
@@ -87,8 +87,8 @@
         "repositoryURL": "https://github.com/vapor/postgresql.git",
         "state": {
           "branch": null,
-          "revision": "830abbc80de4fad428987bea1bf3d43013f17cc1",
-          "version": "1.4.0"
+          "revision": "69ccf32e9164b207f9a773edac5433fe68ae3e5b",
+          "version": "1.5.0"
         }
       },
       {
@@ -96,8 +96,8 @@
         "repositoryURL": "https://github.com/vapor/routing.git",
         "state": {
           "branch": null,
-          "revision": "626190ddd2bd9f967743b60ba6adaf90bbd2651c",
-          "version": "3.0.2"
+          "revision": "d76f339c9716785e5079af9d7075d28ff7da3d92",
+          "version": "3.1.0"
         }
       },
       {
@@ -105,8 +105,8 @@
         "repositoryURL": "https://github.com/vapor/service.git",
         "state": {
           "branch": null,
-          "revision": "4907311d7d7f609365982fa302b8b17ffdeb46da",
-          "version": "1.0.1"
+          "revision": "fa5b5de62bd68bcde9a69933f31319e46c7275fb",
+          "version": "1.0.2"
         }
       },
       {
@@ -114,8 +114,8 @@
         "repositoryURL": "https://github.com/vapor/sql.git",
         "state": {
           "branch": null,
-          "revision": "f77bcae7c95150cdab62095e7bf321ed8c7551bd",
-          "version": "2.3.0"
+          "revision": "50eaeb8f52a1ce63f1ff3880e1114dd8757a78a6",
+          "version": "2.3.2"
         }
       },
       {
@@ -123,8 +123,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "87dbd0216c47ea2e7ddb1b545271b716e03b943e",
-          "version": "1.13.1"
+          "revision": "ba7970fe396e8198b84c6c1b44b38a1d4e2eb6bd",
+          "version": "1.14.1"
         }
       },
       {
@@ -159,8 +159,8 @@
         "repositoryURL": "https://github.com/vapor/template-kit.git",
         "state": {
           "branch": null,
-          "revision": "aff2d6fc65bfd04579b0201b31a8d6720239c1cf",
-          "version": "1.1.1"
+          "revision": "51405c83e95e8adb09565278a5e9b959c605e56c",
+          "version": "1.4.0"
         }
       },
       {
@@ -168,8 +168,8 @@
         "repositoryURL": "https://github.com/vapor/url-encoded-form.git",
         "state": {
           "branch": null,
-          "revision": "932024f363ee5ff59059cf7d67194a1c271d3d0c",
-          "version": "1.0.5"
+          "revision": "82d8d63bdb76b6dd8febe916c639ab8608dbbaed",
+          "version": "1.0.6"
         }
       },
       {
@@ -186,8 +186,8 @@
         "repositoryURL": "https://github.com/vapor/vapor.git",
         "state": {
           "branch": null,
-          "revision": "c86ada59b31c69f08a6abd4f776537cba48d5df6",
-          "version": "3.3.0"
+          "revision": "92a58a9a84e4330500b99fe355a94d29f67abe58",
+          "version": "3.3.1"
         }
       },
       {
@@ -195,8 +195,8 @@
         "repositoryURL": "https://github.com/vapor/websocket.git",
         "state": {
           "branch": null,
-          "revision": "21eb4773e25a8ff96fe347a31fe106900a69fa6a",
-          "version": "1.1.1"
+          "revision": "d85e5b6dce4d04065865f77385fc3324f98178f6",
+          "version": "1.1.2"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -15,8 +15,8 @@ let package = Package(
             from: "3.0.0"
         ),
         .package(
-            url: "https://github.com/vapor/jobs.git",
-            .branch("3")
+            url: "https://github.com/tonyarnold/jobs.git",
+            .branch("feature/backport-delay-until-to-3")
         ),
         .package(
             url: "https://github.com/vapor/fluent-postgres-driver.git",

--- a/Package.swift
+++ b/Package.swift
@@ -1,26 +1,42 @@
-// swift-tools-version:4.2
-
+// swift-tools-version:5.1
 import PackageDescription
 
 let package = Package(
-  name: "JobsPostgreSQLDriver",
-  products: [
-    .library(
-      name: "JobsPostgreSQLDriver",
-      targets: ["JobsPostgreSQLDriver"]),
+    name: "JobsPostgreSQLDriver",
+    products: [
+        .library(
+            name: "JobsPostgreSQLDriver",
+            targets: ["JobsPostgreSQLDriver"]
+        ),
     ],
-  dependencies: [
-    .package(url: "https://github.com/vapor/vapor.git", from: "3.0.0"),
-    .package(url: "https://github.com/vapor-community/jobs.git", from: "0.2.0"),
-    .package(url: "https://github.com/vapor/fluent-postgresql.git", from: "1.0.0")
-  ],
-  targets: [
-    .target(
-      name: "JobsPostgreSQLDriver",
-      dependencies: ["Vapor", "Jobs", "FluentPostgreSQL"]),
-    .testTarget(
-      name: "JobsPostgreSQLDriverTests",
-      dependencies: ["JobsPostgreSQLDriver"]),
+    dependencies: [
+        .package(
+            url: "https://github.com/vapor/vapor.git",
+            from: "3.0.0"
+        ),
+        .package(
+            url: "https://github.com/vapor/jobs.git",
+            .branch("3")
+        ),
+        .package(
+            url: "https://github.com/vapor/fluent-postgres-driver.git",
+            from: "1.0.0"
+        ),
+    ],
+    targets: [
+        .target(
+            name: "JobsPostgreSQLDriver",
+            dependencies: [
+                "Jobs",
+                "FluentPostgreSQL",
+                "Vapor"
+            ]
+        ),
+        .testTarget(
+            name: "JobsPostgreSQLDriverTests",
+            dependencies: [
+                "JobsPostgreSQLDriver"
+            ]
+        ),
     ]
 )
-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JobsPostgreSQLDriver
 
-A package that sits on top of the Jobs package (https://github.com/vapor-community/jobs) and implements PostgreSQL as a persistence layer. 
+A package that sits on top of the Jobs package (https://github.com/vapor/jobs) and implements PostgreSQL as a persistence layer. 
 
 # Installation
 Add this to your Package.swift:

--- a/README.md
+++ b/README.md
@@ -3,25 +3,21 @@
 A package that sits on top of the Jobs package (https://github.com/vapor/jobs) and implements PostgreSQL as a persistence layer. 
 
 # Installation
+
 Add this to your Package.swift:
 
 ```swift
 .package(url: "https://github.com/vapor-community/jobs-postgresql-driver", from: "0.1.0")
 ```
 
-Create the `jobs` table in your database:
+Create the `jobs` table in your database via a migration:
 
 ```swift
-CREATE TABLE job (
-    id SERIAL PRIMARY KEY,
-    key character varying(255) NOT NULL,
-    job_id character varying(255) NOT NULL,
-    data bytea NOT NULL,
-    state character varying(255) NOT NULL,
-    created_at timestamp with time zone NOT NULL DEFAULT clock_timestamp(),
-    updated_at timestamp with time zone NOT NULL DEFAULT clock_timestamp()
-);
-CREATE INDEX job_key_idx ON job(key);
+var migrations = MigrationConfig()
+
+migrations.add(model: JobModel.self, database: .psql)
+
+services.register(migrations)
 ```
 
 Initialize the Jobs service and set the default database for the `JobModel` model in your `configure.swift`:
@@ -39,6 +35,5 @@ try jobs(&services)
 /// Set the default database on the JobModel
 JobModel.defaultDatabase = .psql
 ```
-
 
 Follow the instructions in the `Jobs` package for more setup and configuration information. 

--- a/Sources/JobsPostgreSQLDriver/Exports.swift
+++ b/Sources/JobsPostgreSQLDriver/Exports.swift
@@ -1,0 +1,1 @@
+@_exported import FluentPostgreSQL

--- a/Sources/JobsPostgreSQLDriver/JobsPostgreSQLDriver.swift
+++ b/Sources/JobsPostgreSQLDriver/JobsPostgreSQLDriver.swift
@@ -116,7 +116,8 @@ extension JobsPostgreSQLDriver: JobsPersistenceLayer {
                 .first()
                 .flatMap { jobModel in
                     if let jobModel = jobModel {
-                        // Update the Job's updatedAt date
+                        // Set the Job's state back to pending
+                        jobModel.state = JobState.pending.rawValue
                         jobModel.updatedAt = Date()
                         return jobModel.save(on: conn).transform(to: ())
                     }

--- a/Sources/JobsPostgreSQLDriver/JobsPostgreSQLDriver.swift
+++ b/Sources/JobsPostgreSQLDriver/JobsPostgreSQLDriver.swift
@@ -174,7 +174,16 @@ public final class JobModel: PostgreSQLModel {
 }
 
 /// Allows `JobModel` to be used as a dynamic migration.
-extension JobModel: Migration {}
+extension JobModel: Migration {
+    public static func prepare(on connection: PostgreSQLConnection) -> EventLoopFuture<Void> {
+        return Database.create(self, on: connection) { builder in
+            try addProperties(to: builder)
+        }
+        .flatMap { _ in
+            return connection.create(index: "job_key_idx").on(\JobModel.key).run()
+        }
+    }
+}
 
 /// Allows `JobModel` to be encoded to and decoded from HTTP messages.
 extension JobModel: Content {}

--- a/Sources/JobsPostgreSQLDriver/JobsPostgreSQLDriver.swift
+++ b/Sources/JobsPostgreSQLDriver/JobsPostgreSQLDriver.swift
@@ -1,186 +1,183 @@
-//
-//  JobsPostgreSQLDriver.swift
-//  App
-//
-//  Created by TJ on 14/02/2019.
-//
-
-import Foundation
-import Vapor
-import Jobs
 import FluentPostgreSQL
-import NIO
-
+import Foundation
+import Jobs
+import Vapor
 
 /// A wrapper that conforms to `JobsPersistenceLayer`
 public struct JobsPostgreSQLDriver {
-  
-  /// The `PostgreSQLDatabase` to run commands on
-  let databaseIdentifier: DatabaseIdentifier<PostgreSQLDatabase>
-  
-  /// The `Container` to run jobs on
-  public let container: Container
-  
-  /// Completed jobs should be deleted
-  public let deleteCompletedJobs: Bool
-  
-  /// Creates a new `JobsPostgreSQLDriver` instance
-  ///
-  /// - Parameters:
-  ///   - databaseIdentifier: The `DatabaseIdentifier<PostgreSQLDatabase>` to run commands on
-  ///   - container: The `Container` to run jobs on
-  public init(databaseIdentifier: DatabaseIdentifier<PostgreSQLDatabase>, container: Container, deleteCompletedJobs: Bool = false) {
-    self.databaseIdentifier = databaseIdentifier
-    self.container = container
-    self.deleteCompletedJobs = deleteCompletedJobs
-  }
+    /// The `PostgreSQLDatabase` to run commands on
+    let databaseIdentifier: DatabaseIdentifier<PostgreSQLDatabase>
+
+    /// The `Container` to run jobs on
+    public let container: Container
+
+    /// Completed jobs should be deleted
+    public let deleteCompletedJobs: Bool
+
+    /// Creates a new `JobsPostgreSQLDriver` instance
+    ///
+    /// - Parameters:
+    ///   - databaseIdentifier: The `DatabaseIdentifier<PostgreSQLDatabase>` to run commands on
+    ///   - container: The `Container` to run jobs on
+    public init(databaseIdentifier: DatabaseIdentifier<PostgreSQLDatabase>, container: Container, deleteCompletedJobs: Bool = false) {
+        self.databaseIdentifier = databaseIdentifier
+        self.container = container
+        self.deleteCompletedJobs = deleteCompletedJobs
+    }
 }
 
 extension JobsPostgreSQLDriver: JobsPersistenceLayer {
-  public var eventLoop: EventLoop {
-    return container.next()
-  }
-  
-  public func get(key: String) -> EventLoopFuture<JobStorage?> {
-    // Establish a database connection
-    return container.withPooledConnection(to: databaseIdentifier) { conn in
-      
-      // We ned to use SKIP LOCKED in order to handle multiple threads all getting the next job
-      // Not sure how to make use of SKIP LOCKED in the QueryBuilder, saw raw SQL it is ...
-      let sql = PostgreSQLQuery(stringLiteral: """
-        UPDATE job SET state = 'processing',
-        updated_at = clock_timestamp()
-        WHERE id = (
-        SELECT id
-        FROM job
-        WHERE key = '\(key)'
-        AND state = 'pending'
-        ORDER BY id
-        FOR UPDATE SKIP LOCKED
-        LIMIT 1
-        )
-        RETURNING *
-        """)
-      
-      // Retrieve the next Job
-      return conn.query(sql).map(to: JobStorage?.self) { rows in
-        if let job = rows.first,
-          let data = job.firstValue(name: "data")?.binary {
-          // Now decode the Job for processing
-          let decoder = try JSONDecoder().decode(DecoderUnwrapper.self, from: data)
-          return try JobStorage(from: decoder.decoder)
+    /// The `EventLoop` to run jobs on
+    public var eventLoop: EventLoop {
+        return container.next()
+    }
+
+    /// See `JobsPersistenceLayer.get`
+    public func get(key: String) -> EventLoopFuture<JobStorage?> {
+        // Establish a database connection
+        return container.withPooledConnection(to: databaseIdentifier) { conn in
+            // We need to use SKIP LOCKED in order to handle multiple threads all getting the next job
+            // Not sure how to make use of SKIP LOCKED in the QueryBuilder, saw raw SQL it is ...
+            let sql = PostgreSQLQuery(stringLiteral: """
+            UPDATE job SET state = 'processing', updated_at = clock_timestamp()
+            WHERE id = (
+                SELECT id
+                FROM job
+                WHERE key = '\(key)'
+                AND state = 'pending'
+                ORDER BY id
+                FOR UPDATE SKIP LOCKED
+                LIMIT 1
+            )
+            RETURNING *
+            """)
+
+            // Retrieve the next Job
+            return conn.query(sql).map(to: JobStorage?.self) { rows in
+                guard
+                    let job = rows.first,
+                    let data = job.firstValue(name: "data")?.binary
+                else {
+                    return nil
+                }
+
+                // Now decode the Job for processing
+                let decoder = try JSONDecoder().decode(DecoderUnwrapper.self, from: data)
+                return try JobStorage(from: decoder.decoder)
+            }
         }
-        return nil
-      }
     }
-  }
-  
-  public func set(key: String, jobStorage: JobStorage) -> EventLoopFuture<Void> {
-    // Establish a database connection
-    return container.withPooledConnection(to: databaseIdentifier) { conn in
-      // Encode and save the Job
-      let data = try JSONEncoder().encode(jobStorage)
-      return JobModel(key: key, jobId: jobStorage.id, data: data).save(on: conn).map { jobModel in
-        return
-      }
-    }
-  }
-  
-  public func completed(key: String, jobStorage: JobStorage) -> EventLoopFuture<Void> {
-    // Establish a database connection
-    return container.withPooledConnection(to: databaseIdentifier) { conn in
-      // Update the state
-      return JobModel.query(on: conn).filter(\.jobId == jobStorage.id).first().flatMap { jobModel in
-        if let jobModel = jobModel {
-          // If we are just deleting completed jobs, then delete the job
-          if self.deleteCompletedJobs {
-            return jobModel.delete(on: conn).transform(to: ())
-          }
-          
-          // Otherwise, update the state
-          jobModel.state = JobState.completed.rawValue
-          jobModel.updatedAt = Date()
-          return jobModel.save(on: conn).map(to: Void.self) { jobModel in
-            return
-          }
+
+    public func set(key: String, jobStorage: JobStorage) -> EventLoopFuture<Void> {
+        // Establish a database connection
+        return container.withPooledConnection(to: databaseIdentifier) { conn in
+            // Encode and save the Job
+            let data = try JSONEncoder().encode(jobStorage)
+            return JobModel(key: key, jobId: jobStorage.id, data: data)
+                .save(on: conn)
+                .transform(to: ())
         }
-        
-        return conn.future()
-      }
     }
-  }
-  
-  /// Not used in PostgreSQL implementation!
-  public func processingKey(key: String) -> String {
-    return "\(key)-processing"
-  }
+
+    public func completed(key: String, jobStorage: JobStorage) -> EventLoopFuture<Void> {
+        // Establish a database connection
+        return container.withPooledConnection(to: databaseIdentifier) { conn in
+            // Update the state
+            JobModel.query(on: conn)
+                .filter(\.jobId == jobStorage.id)
+                .first()
+                .flatMap { jobModel in
+                    if let jobModel = jobModel {
+                        // If we are just deleting completed jobs, then delete the job
+                        if self.deleteCompletedJobs {
+                            return jobModel.delete(on: conn).transform(to: ())
+                        }
+
+                        // Otherwise, update the state
+                        jobModel.state = JobState.completed.rawValue
+                        jobModel.updatedAt = Date()
+                        return jobModel.save(on: conn).transform(to: ())
+                    }
+
+                    return conn.future()
+                }
+        }
+    }
+
+    /// Not used in PostgreSQL implementation!
+    public func processingKey(key: String) -> String {
+        return key + "-processing"
+    }
 }
 
 struct DecoderUnwrapper: Decodable {
-  let decoder: Decoder
-  init(from decoder: Decoder) { self.decoder = decoder }
+    let decoder: Decoder
+    init(from decoder: Decoder) { self.decoder = decoder }
 }
 
-enum JobState: String, Codable {
-  case pending = "pending"
-  case processing = "processing"
-  case completed = "completed"
+public enum JobState: String, Codable {
+    case pending
+    case processing
+    case completed
 }
+
 public final class JobModel: PostgreSQLModel {
-  /// Types
-  public typealias Database = PostgreSQLDatabase
-  public typealias ID = Int
-  public static let idKey: IDKey = \.id
-  
-  /// Properties
-  public static let entity = "job"
-  public var id: Int?
-  
-  /// The Job key
-  var key: String
-  /// The unique Job uuid
-  var jobId: String
-  /// The Job data
-  var data: Data
-  /// The current state of the Job
-  var state: String
-  
-  /// The created timestamp
-  var createdAt: Date
-  /// The updated timestamp
-  var updatedAt: Date
-  
-  /// Codable keys
-  enum CodingKeys: String, CodingKey {
-    case id
-    case key
-    case jobId = "job_id"
-    case data
-    case state
-    case createdAt = "created_at"
-    case updatedAt = "updated_at"
-  }
-  
-  init(key: String,
-       jobId: String,
-       data: Data,
-       state: JobState = .pending,
-       createdAt: Date = Date(),
-       updatedAt: Date = Date()) {
-    self.key = key
-    self.jobId = jobId
-    self.data = data
-    self.state = state.rawValue
-    self.createdAt = createdAt
-    self.updatedAt = updatedAt
-  }
+    /// Types
+    public typealias Database = PostgreSQLDatabase
+    public typealias ID = Int
+    public static let idKey: IDKey = \.id
+
+    /// Properties
+    public static let entity = "job"
+    public var id: Int?
+
+    /// The Job key
+    var key: String
+    /// The unique Job uuid
+    var jobId: String
+    /// The Job data
+    var data: Data
+    /// The current state of the Job
+    var state: String
+
+    /// The created timestamp
+    var createdAt: Date
+    /// The updated timestamp
+    var updatedAt: Date
+
+    /// Codable keys
+    enum CodingKeys: String, CodingKey {
+        case id
+        case key
+        case jobId = "job_id"
+        case data
+        case state
+        case createdAt = "created_at"
+        case updatedAt = "updated_at"
+    }
+
+    init(
+        key: String,
+        jobId: String,
+        data: Data,
+        state: JobState = .pending,
+        createdAt: Date = Date(),
+        updatedAt: Date = Date()
+    ) {
+        self.key = key
+        self.jobId = jobId
+        self.data = data
+        self.state = state.rawValue
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
 }
 
 /// Allows `JobModel` to be used as a dynamic migration.
-extension JobModel: Migration { }
+extension JobModel: Migration {}
 
 /// Allows `JobModel` to be encoded to and decoded from HTTP messages.
-extension JobModel: Content { }
+extension JobModel: Content {}
 
 /// Allows `JobModel` to be used as a dynamic parameter in route definitions.
-extension JobModel: Parameter { }
+extension JobModel: Parameter {}

--- a/Tests/JobsPostgreSQLDriverTests/JobsPostgreSQLDriverTests.swift
+++ b/Tests/JobsPostgreSQLDriverTests/JobsPostgreSQLDriverTests.swift
@@ -1,19 +1,11 @@
 import XCTest
-import class Foundation.Bundle
-import JobsPostgreSQLDriver
-import FluentPostgreSQL
-import NIO
 @testable import Jobs
 
 final class JobsPostgreSQLDriverTests: XCTestCase {
-    
-    override func setUp() {
-    }
-    
-    override func tearDown() {
-    }
+    override func setUp() {}
 
-    static var allTests = [
-    ]
+    override func tearDown() {}
+
+    static var allTests: [XCTestCase] = []
 }
 

--- a/Tests/JobsPostgreSQLDriverTests/XCTestManifests.swift
+++ b/Tests/JobsPostgreSQLDriverTests/XCTestManifests.swift
@@ -3,7 +3,7 @@ import XCTest
 #if !os(macOS)
 public func allTests() -> [XCTestCaseEntry] {
     return [
-        testCase(JobsPostgreSQLDriverTests.allTests),
+        testCase(JobsPostgreSQLDriverTests.allTests)
     ]
 }
 #endif


### PR DESCRIPTION
This PR is dependent on #1 and then vapor/jobs#40 being merged before this PR.

It introduces support for the `delayUntil` property, allowing for the scheduling of jobs to run at a later date and time.